### PR TITLE
Don't encode access token in session cookie

### DIFF
--- a/http.go
+++ b/http.go
@@ -25,7 +25,6 @@ const (
 
 	sessionName            = "okta-session"
 	sessionIDTokenKey      = string(IDTokenKey)
-	sessionAccessTokenKey  = "access_token"
 	sessionNonceKey        = "nonce"
 	sessionRedirectPathKey = "redirect_path"
 )
@@ -219,7 +218,6 @@ func (h *AuthHandler) AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	session.Values[sessionIDTokenKey] = exchange.IDToken
-	session.Values[sessionAccessTokenKey] = exchange.AccessToken
 
 	err = session.Save(r, w)
 	if err != nil {


### PR DESCRIPTION
This PR removes the unused access token from the session cookie. 

We were routinely seeing `securecookie: the value is too long`.  I dumped the session.Values, encoding the value in gob format, and evaluated the length of the values.  While these don't come close to this 4096 bytes, the https://github.com/gorilla/sessions/issues/89 indicates the empty-state encoding is already in excess of 1600 bytes.
```
id_token = gob len(1120)
redirect_path = gob len(120)
nonce = gob len(48)
access_token = gob len(893)
```

This package doesn't use or export the access token, only the id token.  There's some details about the differences between the access token and the id token in this document.  https://developer.okta.com/docs/guides/validate-access-tokens/go/main/